### PR TITLE
uses CMAKE_CURRENT_SOURCE_DIR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (ANDROID)
 endif()
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${THIRDPART_INC}
 )


### PR DESCRIPTION
I was trying to build this library by doing add_subdirectory so when I build my project it builds the library by itself, but line 43 was adding the include files of the cmake source that was used to launch the `cmake .` command, not the current one being built, so I changed to `CMAKE_CURRENT_SOURCE_DIR` and it worked