### PR TITLE
Auto call shutdown at xxsocket::close

### DIFF
--- a/yasio/xxsocket.cpp
+++ b/yasio/xxsocket.cpp
@@ -1277,6 +1277,7 @@ void xxsocket::close(void)
 {
   if (is_open())
   {
+    shutdown();
     ::closesocket(this->fd);
     this->fd = invalid_socket;
   }

--- a/yasio/xxsocket.cpp
+++ b/yasio/xxsocket.cpp
@@ -1273,11 +1273,12 @@ bool xxsocket::alive(void) const { return this->send("", 0) != -1; }
 
 int xxsocket::shutdown(int how) const { return ::shutdown(this->fd, how); }
 
-void xxsocket::close(void)
+void xxsocket::close(int shut_how)
 {
   if (is_open())
   {
-    shutdown();
+    if (shut_how >= 0)
+      ::shutdown(this->fd, shut_how);
     ::closesocket(this->fd);
     this->fd = invalid_socket;
   }

--- a/yasio/xxsocket.hpp
+++ b/yasio/xxsocket.hpp
@@ -105,6 +105,8 @@ typedef int socklen_t;
 typedef int socket_native_type;
 #  undef socket
 #endif
+#define SD_NONE -1
+
 #include <fcntl.h> // common platform header
 
 // redefine socket error code for posix api
@@ -1060,11 +1062,11 @@ public:
 
   /* @brief: close sends
    ** @params:
-   **        non
+   **        shut_how: [SD_SEND] or [SD_RECEIVE] or [SD_BOTH] or [SD_NONE]
    **
    ** @returns: [0] succeed, otherwise, a value of SOCKET_ERROR is returned.
    */
-  YASIO__DECL void close(void);
+  YASIO__DECL void close(int shut_how = SD_BOTH);
 
   /* @brief: Retrive tcp socket rtt in microseconds
    ** @params:


### PR DESCRIPTION
Before close socket, call shutdown first to ensure the accept and recv function will break from blocking in Linux.