### PR TITLE
Fix spelling error and add external to include-path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ else ( )
     )
 endif ( )
 
-target_include_directories(${yasio_target_name} PUBLIC ${CMAKE_CURRENT_DOURCE_DIR}/)
+target_include_directories(${yasio_target_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/external)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(${yasio_target_name} 


### PR DESCRIPTION
把external的路径添加到包含目录列表中，这样外部通过add_subdirectory引用yasio
的项目也自动把external目录添加到包含目录中了，避免找不到头文件。