### PR TITLE
Improve binary reader and writer

### DIFF
--- a/.github/workflows/freebsd-ci.yml
+++ b/.github/workflows/freebsd-ci.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Build
-      uses: vmactions/freebsd-vm@v0.1.4
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         envs: 'TRAVIS_OS_NAME BUILD_TARGET'
         usesh: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Build
-        uses: vmactions/freebsd-vm@v0.1.0
+        uses: vmactions/freebsd-vm@v0.1.5
         with:
           prepare: pkg install -y cmake
           run: |

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -1,6 +1,6 @@
 # Install latest cmake version for appveyor ci
 if (!($env:GITHUB_CI -eq "true")) {
-    $cmake_ver="3.21.3"
+    $cmake_ver="3.22.0"
     curl "https://github.com/Kitware/CMake/releases/download/v$cmake_ver/cmake-$cmake_ver-windows-x86_64.zip" -o "cmake-$cmake_ver-windows-x86_64.zip"
     Expand-Archive -Path cmake-$cmake_ver-windows-x86_64.zip -DestinationPath .\
     $cmake_bin = (Resolve-Path .\cmake-$cmake_ver-windows-x86_64\bin).Path

--- a/tests/tcp/main.cpp
+++ b/tests/tcp/main.cpp
@@ -187,6 +187,17 @@ void yasioTest()
 #else
   std::cout << r0 << ", " << r1 << ", " << f1 << ", " << v5 << ", " << v6 << ", " << v8 << "\n";
 #endif
+
+  std::vector<char> vecbuf;
+  std::string strbuf;
+  std::array<char, 16> arrbuf;
+  char raw_arrbuf[16];
+  yasio::obstream_span<std::vector<char>>{vecbuf}.write_bytes("hello world!");
+  yasio::obstream_span<std::string>{strbuf}.write_bytes("hello world!");
+  yasio::obstream_span<yasio::fixed_buffer_span>{arrbuf}.write_bytes("hello world!");
+  yasio::obstream_span<yasio::fixed_buffer_span>{raw_arrbuf}.write_bytes("hello world!");
+
+
   io_service service(endpoints, YASIO_ARRAYSIZE(endpoints));
 
   resolv_fn_t resolv = [&](std::vector<ip::endpoint>& endpoints, const char* hostname, unsigned short port) {

--- a/yasio/detail/config.hpp
+++ b/yasio/detail/config.hpp
@@ -186,7 +186,7 @@ SOFTWARE.
 /*
 **  The yasio version macros
 */
-#define YASIO_VERSION_NUM 0x033708
+#define YASIO_VERSION_NUM 0x033709
 
 /*
 ** The macros used by io_service.

--- a/yasio/detail/ibstream.hpp
+++ b/yasio/detail/ibstream.hpp
@@ -256,7 +256,7 @@ public:
   cxx17::string_view range_view(size_t start, size_t end)
   {
     if (start <= end && (first_ + end) <= last_)
-      return cxx17::string_view{first_ + start, first_ + end};
+      return cxx17::string_view{first_ + start, end - start};
     return cxx17::string_view{};
   }
 

--- a/yasio/detail/ibstream.hpp
+++ b/yasio/detail/ibstream.hpp
@@ -123,8 +123,9 @@ public:
   using convert_traits_type = _Traits;
   using this_type           = binary_reader_impl<_Traits>;
   binary_reader_impl() { this->reset("", 0); }
+  binary_reader_impl(const std::vector<char>& d) { this->reset(d); }
+  binary_reader_impl(const cxx17::string_view& d) { this->reset(d); }
   binary_reader_impl(const void* data, size_t size) { this->reset(data, size); }
-
   template <typename _BufferType>
   binary_reader_impl(const binary_writer_impl<_Traits, _BufferType>* obs)
   {
@@ -142,6 +143,8 @@ public:
 
   ~binary_reader_impl() {}
 
+  void reset(const std::vector<char>& d) { reset(d.data(), d.size()); }
+  void reset(const cxx17::string_view& d) { reset(d.data(), d.length()); }
   void reset(const void* data, size_t size)
   {
     first_ = ptr_ = static_cast<const char*>(data);
@@ -208,6 +211,7 @@ public:
   const char* data() const { return first_; }
 
   void advance(ptrdiff_t offset) { ptr_ += offset; }
+  void advance_v() { advance(read_ix<int>()); }
   ptrdiff_t tell() const { return ptr_ - first_; }
   ptrdiff_t seek(ptrdiff_t offset, int whence)
   {

--- a/yasio/detail/ibstream.hpp
+++ b/yasio/detail/ibstream.hpp
@@ -32,9 +32,11 @@ namespace yasio
 {
 namespace detail
 {
-template <typename _Stream, typename _Intty> struct read_ix_helper {};
+template <typename _Stream, typename _Intty>
+struct read_ix_helper {};
 
-template <typename _Stream> struct read_ix_helper<_Stream, int32_t> {
+template <typename _Stream>
+struct read_ix_helper<_Stream, int32_t> {
   static int32_t read_ix(_Stream* stream)
   {
     // Unlike writing, we can't delegate to the 64-bit read on
@@ -75,7 +77,8 @@ template <typename _Stream> struct read_ix_helper<_Stream, int32_t> {
   }
 };
 
-template <typename _Stream> struct read_ix_helper<_Stream, int64_t> {
+template <typename _Stream>
+struct read_ix_helper<_Stream, int64_t> {
   static int64_t read_ix(_Stream* stream)
   {
     uint64_t result = 0;
@@ -114,18 +117,22 @@ template <typename _Stream> struct read_ix_helper<_Stream, int64_t> {
 };
 } // namespace detail
 
-template <typename _Traits> class basic_ibstream_view {
+template <typename _Traits>
+class basic_ibstream_view {
 public:
   using convert_traits_type = _Traits;
   using this_type           = basic_ibstream_view<_Traits>;
   basic_ibstream_view() { this->reset("", 0); }
   basic_ibstream_view(const void* data, size_t size) { this->reset(data, size); }
 
-  template<typename _BufferType>
-  basic_ibstream_view(const basic_obstream_view<_Traits, _BufferType>* obs) { this->reset(obs->data(), obs->length()); }
+  template <typename _BufferType>
+  basic_ibstream_view(const basic_obstream_span_any<_Traits, _BufferType>* obs)
+  {
+    this->reset(obs->data(), obs->length());
+  }
 
   template <typename _BufferType>
-  basic_ibstream_view(const basic_obstream_view<_Traits, _BufferType>* obs, ptrdiff_t offset)
+  basic_ibstream_view(const basic_obstream_span_any<_Traits, _BufferType>* obs, ptrdiff_t offset)
   {
     this->reset(obs->data(), obs->length());
     this->advance(offset);
@@ -147,7 +154,11 @@ public:
   /* read 7bit encoded variant integer value
   ** @dotnet BinaryReader.Read7BitEncodedInt(64)
   */
-  template <typename _Intty> _Intty read_ix() { return detail::read_ix_helper<this_type, _Intty>::read_ix(this); }
+  template <typename _Intty>
+  _Intty read_ix()
+  {
+    return detail::read_ix_helper<this_type, _Intty>::read_ix(this);
+  }
 
   int read_varint(int size)
   {
@@ -220,15 +231,21 @@ public:
     return ptr_ - first_;
   }
 
-  template <typename _Nty> inline _Nty read() { return sread<_Nty>(consume(sizeof(_Nty))); }
-  template <typename _Nty> static _Nty sread(const void* ptr)
+  template <typename _Nty>
+  inline _Nty read()
+  {
+    return sread<_Nty>(consume(sizeof(_Nty)));
+  }
+  template <typename _Nty>
+  static _Nty sread(const void* ptr)
   {
     _Nty value;
     ::memcpy(&value, ptr, sizeof(value));
     return convert_traits_type::template from<_Nty>(value);
   }
 
-  template <typename _LenT> inline cxx17::string_view read_v_fx()
+  template <typename _LenT>
+  inline cxx17::string_view read_v_fx()
   {
     _LenT n = this->read<_LenT>();
     if (n > 0)
@@ -256,7 +273,8 @@ protected:
 };
 
 /// --------------------- CLASS ibstream ---------------------
-template <typename _Traits> class basic_ibstream : public basic_ibstream_view<_Traits> {
+template <typename _Traits>
+class basic_ibstream : public basic_ibstream_view<_Traits> {
 public:
   basic_ibstream() {}
   basic_ibstream(std::vector<char> blob) : basic_ibstream_view<_Traits>(), blob_(std::move(blob)) { this->reset(blob_.data(), static_cast<int>(blob_.size())); }

--- a/yasio/detail/inet_compat.inl
+++ b/yasio/detail/inet_compat.inl
@@ -64,8 +64,8 @@ SOFTWARE.
  * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
  */
 
-static const char* inet_ntop4(const u_char* src, char* dst, socklen_t size);
-static const char* inet_ntop6(const u_char* src, char* dst, socklen_t size);
+static const char* inet_ntop4(const u_char* src, char* dst, size_t size);
+static const char* inet_ntop6(const u_char* src, char* dst, size_t size);
 
 /* char *
  * inet_ntop(af, src, dst, size)
@@ -75,7 +75,7 @@ static const char* inet_ntop6(const u_char* src, char* dst, socklen_t size);
  * author:
  *	Paul Vixie, 1996.
  */
-const char* inet_ntop(int af, const void* src, char* dst, socklen_t size)
+const char* inet_ntop(int af, const void* src, char* dst, size_t size)
 {
   switch (af)
   {
@@ -101,7 +101,7 @@ const char* inet_ntop(int af, const void* src, char* dst, socklen_t size)
  * author:
  *	Paul Vixie, 1996.
  */
-static const char* inet_ntop4(const u_char* src, char* dst, socklen_t size)
+static const char* inet_ntop4(const u_char* src, char* dst, size_t size)
 {
   char fmt[] = "%u.%u.%u.%u";
   char tmp[sizeof "255.255.255.255"];
@@ -120,7 +120,7 @@ static const char* inet_ntop4(const u_char* src, char* dst, socklen_t size)
  * author:
  *	Paul Vixie, 1996.
  */
-static const char* inet_ntop6(const u_char* src, char* dst, socklen_t size)
+static const char* inet_ntop6(const u_char* src, char* dst, size_t size)
 {
   /*
    * Note that int32_t and int16_t need only be "at least" large enough
@@ -197,7 +197,7 @@ static const char* inet_ntop6(const u_char* src, char* dst, socklen_t size)
     /* Is this address an encapsulated IPv4? */
     if (i == 6 && best.base == 0 && (best.len == 6 || (best.len == 5 && words[5] == 0xffff)))
     {
-      if (!inet_ntop4(src + 12, tp, static_cast<socklen_t>(sizeof tmp - (tp - tmp))))
+      if (!inet_ntop4(src + 12, tp, static_cast<size_t>(sizeof tmp - (tp - tmp))))
         return (nullptr);
       tp += strlen(tp);
       break;
@@ -212,7 +212,7 @@ static const char* inet_ntop6(const u_char* src, char* dst, socklen_t size)
   /*
    * Check for overflow, copy, and we're done.
    */
-  if ((socklen_t)(tp - tmp) > size)
+  if ((size_t)(tp - tmp) > size)
   {
     errno = (ENOSPC);
     return (nullptr);

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -168,7 +168,7 @@ public:
 
   void resize(size_t newsize) { outs_->resize(newsize); }
   void reserve(size_t capacity) { outs_->reserve(capacity); }
-  void shrink_to_fit(){};
+  void shrink_to_fit() { outs_->shrink_to_fit(); };
   void clear() { outs_->clear(); }
   char* data() { return outs_->data(); }
   size_t length() const { return outs_->size(); }

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -145,7 +145,7 @@ private:
 template <typename _Cont = std::vector<char>>
 class dynamic_buffer_span {
 public:
-  using implementation_type = typename _Cont;
+  using implementation_type = _Cont;
   implementation_type& get_implementation() { return *this->outs_; }
   const implementation_type& get_implementation() const { return *this->impl_; }
 

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -72,22 +72,22 @@ struct write_ix_helper<_Stream, int64_t> {
 };
 } // namespace detail
 
-class fixed_buffer_view {
+class fixed_buffer_span {
 public:
-  using implementation_type = fixed_buffer_view;
+  using implementation_type = fixed_buffer_span;
   implementation_type& get_implementation() { return *this; }
   const implementation_type& get_implementation() const { return *this; }
 
   template <size_t _Extent>
-  fixed_buffer_view(std::array<char, _Extent>& buf) : first_(buf.data()), last_(buf.data() + _Extent)
+  fixed_buffer_span(std::array<char, _Extent>& fb) : first_(fb.data()), last_(fb.data() + _Extent)
   {}
 
   template <size_t _Extent>
-  fixed_buffer_view(char (&buf)[_Extent]) : first_(buf), last_(buf + _Extent)
+  fixed_buffer_span(char (&fb)[_Extent]) : first_(fb), last_(fb + _Extent)
   {}
 
-  fixed_buffer_view(char* buf, size_t n) : first_(buf), last_(buf + n) {}
-  fixed_buffer_view(char* first, char* last) : first_(first), last_(last) {}
+  fixed_buffer_span(char* fb, size_t extent) : first_(fb), last_(fb + extent) {}
+  fixed_buffer_span(char* first, char* last) : first_(first), last_(last) {}
 
   void write_byte(uint8_t value)
   {
@@ -106,7 +106,7 @@ public:
   void write_bytes(size_t offset, const void* d, int n)
   {
     if (yasio__unlikely((offset + n) > this->max_size()))
-      YASIO__THROW0(std::out_of_range("fixed_buffer_view: out of range"));
+      YASIO__THROW0(std::out_of_range("fixed_buffer_span: out of range"));
     ::memcpy(this->data() + offset, d, n);
     this->pos_ += n;
   }
@@ -114,7 +114,7 @@ public:
   void resize(size_t newsize)
   {
     if (yasio__unlikely(newsize > max_size()))
-      YASIO__THROW0(std::out_of_range("fixed_buffer_view: out of range"));
+      YASIO__THROW0(std::out_of_range("fixed_buffer_span: out of range"));
     this->pos_ = newsize;
   }
 
@@ -131,61 +131,74 @@ private:
   char* last_;
   size_t pos_ = 0;
 };
+using fixed_buffer_view = fixed_buffer_span;
 
 template <size_t _Extent>
-class fixed_buffer : public fixed_buffer_view {
+class fixed_buffer : public fixed_buffer_span {
 public:
-  fixed_buffer() : fixed_buffer_view(impl_) {}
+  fixed_buffer() : fixed_buffer_span(impl_) {}
 
 private:
   std::array<char, _Extent> impl_;
 };
 
-class dynamic_buffer {
+template <typename _Cont = std::vector<char>>
+class dynamic_buffer_span {
 public:
-  using implementation_type = std::vector<char>;
-  implementation_type& get_implementation() { return this->impl_; }
-  const implementation_type& get_implementation() const { return this->impl_; }
+  using implementation_type = typename _Cont;
+  implementation_type& get_implementation() { return *this->outs_; }
+  const implementation_type& get_implementation() const { return *this->impl_; }
 
-  void write_byte(uint8_t value) { impl_.push_back(value); }
+  dynamic_buffer_span(_Cont* outs) : outs_(outs) {}
+
+  void write_byte(uint8_t value) { outs_->push_back(value); }
   void write_bytes(const void* d, int n)
   {
     if (n > 0)
-      impl_.insert(impl_.end(), static_cast<const char*>(d), static_cast<const char*>(d) + n);
+      outs_->insert(outs_->end(), static_cast<const char*>(d), static_cast<const char*>(d) + n);
   }
   size_t write_bytes(size_t offset, const void* d, int n)
   {
-    if ((offset + n) > impl_.size())
-      impl_.resize(offset + n);
+    if ((offset + n) > outs_->size())
+      outs_->resize(offset + n);
 
-    ::memcpy(impl_.data() + offset, d, n);
+    ::memcpy(outs_->data() + offset, d, n);
     return n;
   }
 
-  void resize(size_t newsize) { impl_.resize(newsize); }
-  void reserve(size_t capacity) { impl_.reserve(capacity); }
+  void resize(size_t newsize) { outs_->resize(newsize); }
+  void reserve(size_t capacity) { outs_->reserve(capacity); }
   void shrink_to_fit(){};
-  void clear() { impl_.clear(); }
-  char* data() { return impl_.data(); }
-  size_t length() const { return impl_.size(); }
-  bool empty() const { return impl_.empty(); }
+  void clear() { outs_->clear(); }
+  char* data() { return outs_->data(); }
+  size_t length() const { return outs_->size(); }
+  bool empty() const { return outs_->empty(); }
+
+private:
+  implementation_type* outs_;
+};
+
+template <typename _Cont = std::vector<char>>
+class dynamic_buffer : public dynamic_buffer_span<_Cont> {
+public:
+  dynamic_buffer() : dynamic_buffer_span<_Cont>(&impl_) {}
 
 private:
   implementation_type impl_;
 };
 
-template <typename _ConvertTraits, typename _BufferType = fixed_buffer_view>
-class basic_obstream_view {
+template <typename _ConvertTraits, typename _BufferType = fixed_buffer_span>
+class basic_obstream_span_any {
 public:
   using convert_traits_type        = _ConvertTraits;
   using buffer_type                = _BufferType;
   using buffer_implementation_type = typename buffer_type::implementation_type;
-  using my_type                    = basic_obstream_view<convert_traits_type, buffer_type>;
+  using my_type                    = basic_obstream_span_any<convert_traits_type, buffer_type>;
 
   static const size_t npos = -1;
 
-  basic_obstream_view(buffer_type* outs) : outs_(outs) {}
-  ~basic_obstream_view() {}
+  basic_obstream_span_any(buffer_type* outs) : outs_(outs) {}
+  ~basic_obstream_span_any() {}
 
   void push8()
   {
@@ -376,26 +389,15 @@ private:
 protected:
   buffer_type* outs_;
   std::stack<size_t> offset_stack_;
-}; // CLASS basic_obstream
+}; // CLASS basic_obstream_span_any
 
+// -------- basic_obstream
 template <typename _ConvertTraits, size_t _Extent = dynamic_extent>
 class basic_obstream;
 
-template <typename _ConvertTraits, size_t _Extent>
-class basic_obstream : public basic_obstream_view<_ConvertTraits, fixed_buffer<_Extent>> {
-  using super_type = basic_obstream_view<_ConvertTraits, fixed_buffer<_Extent>>;
-
-public:
-  using buffer_type = typename super_type::buffer_type;
-  basic_obstream() : super_type(&buffer_) {}
-
-protected:
-  buffer_type buffer_;
-};
-
 template <typename _ConvertTraits>
-class basic_obstream<_ConvertTraits, dynamic_extent> : public basic_obstream_view<_ConvertTraits, dynamic_buffer> {
-  using super_type = basic_obstream_view<_ConvertTraits, dynamic_buffer>;
+class basic_obstream<_ConvertTraits, dynamic_extent> : public basic_obstream_span_any<_ConvertTraits, dynamic_buffer<>> {
+  using super_type = basic_obstream_span_any<_ConvertTraits, dynamic_buffer<>>;
   using my_type    = basic_obstream<_ConvertTraits, dynamic_extent>;
 
 public:
@@ -432,15 +434,83 @@ protected:
   buffer_type buffer_;
 };
 
-using obstream_view = basic_obstream_view<convert_traits<network_convert_tag>>;
+template <typename _ConvertTraits, size_t _Extent>
+class basic_obstream : public basic_obstream_span_any<_ConvertTraits, fixed_buffer<_Extent>> {
+  using super_type = basic_obstream_span_any<_ConvertTraits, fixed_buffer<_Extent>>;
+
+public:
+  using buffer_type = typename super_type::buffer_type;
+  basic_obstream() : super_type(&buffer_) {}
+
+protected:
+  buffer_type buffer_;
+};
+
 template <size_t _Extent>
 using obstream_any = basic_obstream<convert_traits<network_convert_tag>, _Extent>;
 using obstream     = obstream_any<dynamic_extent>;
 
-using fast_obstream_view = basic_obstream_view<convert_traits<host_convert_tag>>;
 template <size_t _Extent>
 using fast_obstream_any = basic_obstream<convert_traits<host_convert_tag>, _Extent>;
 using fast_obstream     = fast_obstream_any<dynamic_extent>;
+
+//-------- basic_obstream_span
+template <typename _ConvertTraits, typename _Cont = std::vector<char>>
+class basic_obstream_span;
+
+template <typename _ConvertTraits, typename _Cont>
+class basic_obstream_span : public basic_obstream_span_any<_ConvertTraits, dynamic_buffer_span<_Cont>> {
+  using super_type = basic_obstream_span_any<_ConvertTraits, dynamic_buffer_span<_Cont>>;
+  using my_type    = basic_obstream_span<_ConvertTraits, _Cont>;
+
+public:
+  using buffer_type = typename super_type::buffer_type;
+  basic_obstream_span(_Cont& outs) : super_type(&span_), span_(&outs) {}
+
+protected:
+  yasio::dynamic_buffer_span<_Cont> span_;
+};
+
+template <typename _ConvertTraits>
+class basic_obstream_span<_ConvertTraits, fixed_buffer_span> : public basic_obstream_span_any<_ConvertTraits, fixed_buffer_span> {
+  using super_type = basic_obstream_span_any<_ConvertTraits, fixed_buffer_span>;
+  using my_type    = basic_obstream_span<_ConvertTraits, fixed_buffer_span>;
+
+public:
+  using buffer_type = typename super_type::buffer_type;
+
+  template <size_t _Extent>
+  basic_obstream_span(std::array<char, _Extent>& buf) : super_type(&span_), span_(buf)
+  {}
+
+  template <size_t _Extent>
+  basic_obstream_span(char (&buf)[_Extent]) : super_type(&span_), span_(buf)
+  {}
+
+  basic_obstream_span(char* buf, size_t n) : super_type(&span_), span_(buf, n) {}
+
+protected:
+  fixed_buffer_span span_;
+};
+
+using fixed_obstream_span      = basic_obstream_span_any<convert_traits<network_convert_tag>, yasio::fixed_buffer_span>;
+using fast_fixed_obstream_span = basic_obstream_span_any<convert_traits<host_convert_tag>, yasio::fixed_buffer_span>;
+
+using obstream_view      = fixed_obstream_span;
+using fast_obstream_view = fast_fixed_obstream_span;
+
+template <typename _Cont>
+using obstream_span = basic_obstream_span<convert_traits<network_convert_tag>, _Cont>;
+template <typename _Cont>
+using fast_obstream_span = basic_obstream_span<convert_traits<host_convert_tag>, _Cont>;
+
+template <size_t _Extent>
+using obstream_any = basic_obstream<convert_traits<network_convert_tag>, _Extent>;
+template <size_t _Extent>
+using fast_obstream_any = basic_obstream<convert_traits<host_convert_tag>, _Extent>;
+
+using obstream      = obstream_any<dynamic_extent>;
+using fast_obstream = fast_obstream_any<dynamic_extent>;
 
 } // namespace yasio
 

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -188,17 +188,17 @@ private:
 };
 
 template <typename _ConvertTraits, typename _BufferType = fixed_buffer_span>
-class basic_obstream_span_any {
+class binary_writer_impl {
 public:
   using convert_traits_type        = _ConvertTraits;
   using buffer_type                = _BufferType;
   using buffer_implementation_type = typename buffer_type::implementation_type;
-  using my_type                    = basic_obstream_span_any<convert_traits_type, buffer_type>;
+  using my_type                    = binary_writer_impl<convert_traits_type, buffer_type>;
 
   static const size_t npos = -1;
 
-  basic_obstream_span_any(buffer_type* outs) : outs_(outs) {}
-  ~basic_obstream_span_any() {}
+  binary_writer_impl(buffer_type* outs) : outs_(outs) {}
+  ~binary_writer_impl() {}
 
   void push8()
   {
@@ -389,10 +389,10 @@ private:
 protected:
   buffer_type* outs_;
   std::stack<size_t> offset_stack_;
-}; // CLASS basic_obstream_span_any
+}; // CLASS binary_writer_impl
 
-using fixed_obstream_span      = basic_obstream_span_any<convert_traits<network_convert_tag>, yasio::fixed_buffer_span>;
-using fast_fixed_obstream_span = basic_obstream_span_any<convert_traits<host_convert_tag>, yasio::fixed_buffer_span>;
+using fixed_obstream_span      = binary_writer_impl<convert_traits<network_convert_tag>, fixed_buffer_span>;
+using fast_fixed_obstream_span = binary_writer_impl<convert_traits<host_convert_tag>, fixed_buffer_span>;
 
 using obstream_view      = fixed_obstream_span;
 using fast_obstream_view = fast_fixed_obstream_span;
@@ -402,8 +402,8 @@ template <typename _ConvertTraits, size_t _Extent = dynamic_extent>
 class basic_obstream;
 
 template <typename _ConvertTraits>
-class basic_obstream<_ConvertTraits, dynamic_extent> : public basic_obstream_span_any<_ConvertTraits, dynamic_buffer<>> {
-  using super_type = basic_obstream_span_any<_ConvertTraits, dynamic_buffer<>>;
+class basic_obstream<_ConvertTraits, dynamic_extent> : public binary_writer_impl<_ConvertTraits, dynamic_buffer<>> {
+  using super_type = binary_writer_impl<_ConvertTraits, dynamic_buffer<>>;
   using my_type    = basic_obstream<_ConvertTraits, dynamic_extent>;
 
 public:
@@ -441,8 +441,8 @@ protected:
 };
 
 template <typename _ConvertTraits, size_t _Extent>
-class basic_obstream : public basic_obstream_span_any<_ConvertTraits, fixed_buffer<_Extent>> {
-  using super_type = basic_obstream_span_any<_ConvertTraits, fixed_buffer<_Extent>>;
+class basic_obstream : public binary_writer_impl<_ConvertTraits, fixed_buffer<_Extent>> {
+  using super_type = binary_writer_impl<_ConvertTraits, fixed_buffer<_Extent>>;
 
 public:
   using buffer_type = typename super_type::buffer_type;
@@ -465,8 +465,8 @@ template <typename _ConvertTraits, typename _Cont = std::vector<char>>
 class basic_obstream_span;
 
 template <typename _ConvertTraits, typename _Cont>
-class basic_obstream_span : public basic_obstream_span_any<_ConvertTraits, dynamic_buffer_span<_Cont>> {
-  using super_type = basic_obstream_span_any<_ConvertTraits, dynamic_buffer_span<_Cont>>;
+class basic_obstream_span : public binary_writer_impl<_ConvertTraits, dynamic_buffer_span<_Cont>> {
+  using super_type = binary_writer_impl<_ConvertTraits, dynamic_buffer_span<_Cont>>;
   using my_type    = basic_obstream_span<_ConvertTraits, _Cont>;
 
 public:
@@ -474,29 +474,29 @@ public:
   basic_obstream_span(_Cont& outs) : super_type(&span_), span_(&outs) {}
 
 protected:
-  yasio::dynamic_buffer_span<_Cont> span_;
+  buffer_type span_;
 };
 
 template <typename _ConvertTraits>
-class basic_obstream_span<_ConvertTraits, fixed_buffer_span> : public basic_obstream_span_any<_ConvertTraits, fixed_buffer_span> {
-  using super_type = basic_obstream_span_any<_ConvertTraits, fixed_buffer_span>;
+class basic_obstream_span<_ConvertTraits, fixed_buffer_span> : public binary_writer_impl<_ConvertTraits, fixed_buffer_span> {
+  using super_type = binary_writer_impl<_ConvertTraits, fixed_buffer_span>;
   using my_type    = basic_obstream_span<_ConvertTraits, fixed_buffer_span>;
 
 public:
   using buffer_type = typename super_type::buffer_type;
 
   template <size_t _Extent>
-  basic_obstream_span(std::array<char, _Extent>& buf) : super_type(&span_), span_(buf)
+  basic_obstream_span(std::array<char, _Extent>& fb) : super_type(&span_), span_(fb)
   {}
 
   template <size_t _Extent>
-  basic_obstream_span(char (&buf)[_Extent]) : super_type(&span_), span_(buf)
+  basic_obstream_span(char (&fb)[_Extent]) : super_type(&span_), span_(fb)
   {}
 
-  basic_obstream_span(char* buf, size_t n) : super_type(&span_), span_(buf, n) {}
+  basic_obstream_span(char* fb, size_t extent) : super_type(&span_), span_(fb, extent) {}
 
 protected:
-  fixed_buffer_span span_;
+  buffer_type span_;
 };
 
 template <typename _Cont>

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -391,6 +391,12 @@ protected:
   std::stack<size_t> offset_stack_;
 }; // CLASS basic_obstream_span_any
 
+using fixed_obstream_span      = basic_obstream_span_any<convert_traits<network_convert_tag>, yasio::fixed_buffer_span>;
+using fast_fixed_obstream_span = basic_obstream_span_any<convert_traits<host_convert_tag>, yasio::fixed_buffer_span>;
+
+using obstream_view      = fixed_obstream_span;
+using fast_obstream_view = fast_fixed_obstream_span;
+
 // -------- basic_obstream
 template <typename _ConvertTraits, size_t _Extent = dynamic_extent>
 class basic_obstream;
@@ -448,11 +454,11 @@ protected:
 
 template <size_t _Extent>
 using obstream_any = basic_obstream<convert_traits<network_convert_tag>, _Extent>;
-using obstream     = obstream_any<dynamic_extent>;
-
 template <size_t _Extent>
 using fast_obstream_any = basic_obstream<convert_traits<host_convert_tag>, _Extent>;
-using fast_obstream     = fast_obstream_any<dynamic_extent>;
+
+using obstream      = obstream_any<dynamic_extent>;
+using fast_obstream = fast_obstream_any<dynamic_extent>;
 
 //-------- basic_obstream_span
 template <typename _ConvertTraits, typename _Cont = std::vector<char>>
@@ -493,24 +499,10 @@ protected:
   fixed_buffer_span span_;
 };
 
-using fixed_obstream_span      = basic_obstream_span_any<convert_traits<network_convert_tag>, yasio::fixed_buffer_span>;
-using fast_fixed_obstream_span = basic_obstream_span_any<convert_traits<host_convert_tag>, yasio::fixed_buffer_span>;
-
-using obstream_view      = fixed_obstream_span;
-using fast_obstream_view = fast_fixed_obstream_span;
-
 template <typename _Cont>
 using obstream_span = basic_obstream_span<convert_traits<network_convert_tag>, _Cont>;
 template <typename _Cont>
 using fast_obstream_span = basic_obstream_span<convert_traits<host_convert_tag>, _Cont>;
-
-template <size_t _Extent>
-using obstream_any = basic_obstream<convert_traits<network_convert_tag>, _Extent>;
-template <size_t _Extent>
-using fast_obstream_any = basic_obstream<convert_traits<host_convert_tag>, _Extent>;
-
-using obstream      = obstream_any<dynamic_extent>;
-using fast_obstream = fast_obstream_any<dynamic_extent>;
 
 } // namespace yasio
 

--- a/yasio/detail/obstream.hpp
+++ b/yasio/detail/obstream.hpp
@@ -184,7 +184,7 @@ public:
   dynamic_buffer() : dynamic_buffer_span<_Cont>(&impl_) {}
 
 private:
-  implementation_type impl_;
+  _Cont impl_;
 };
 
 template <typename _ConvertTraits, typename _BufferType = fixed_buffer_span>

--- a/yasio/xxsocket.hpp
+++ b/yasio/xxsocket.hpp
@@ -188,7 +188,7 @@ namespace compat
 using ::inet_ntop;
 using ::inet_pton;
 #else
-YASIO__DECL const char* inet_ntop(int af, const void* src, char* dst, socklen_t);
+YASIO__DECL const char* inet_ntop(int af, const void* src, char* dst, size_t);
 YASIO__DECL int inet_pton(int af, const char* src, void* dst);
 #endif
 } // namespace compat


### PR DESCRIPTION
Major concept:
- class suffix
    - _view: readonly for ibstream
    - _span: writable for obstream
- classes:
    - binary_writer_impl
    - binary_reader_impl
    - obstream
    - obstream_any
    - obstream_span
    - ibstream_view
    - ibstream
## obstream_span usage
```cpp
std::vector<char> buf1;
yasio::obstream_span<std::vector<char>> obs1(buf1);
```