### PR TITLE
Refactor fd set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+yasio-3.39.6
+  
+  1. Reimplement reactor backends: select, poll
+  2. Now the default reactor backend is poll
+  3. Add compiler flag `YASIO_DISABLE_POLL` for switching to socket.select as same with previous releases
+  
+  
 yasio-3.39.5
   
   1. Fix no callback when resolve domain failed by `getaddrinfo`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,7 @@ macro (yasio_config_lib_options target_name)
     yasio_config_pred(${target_name} YASIO_HAVE_HALF_FLOAT)
     yasio_config_pred(${target_name} YASIO_ENABLE_PASSIVE_EVENT)
     yasio_config_pred(${target_name} YASIO_NO_JNI_ONLOAD)
+    yasio_config_pred(${target_name} YASIO_DISABLE_POLL)
 endmacro()
 
 yasio_config_lib_options(${yasio_target_name})

--- a/yasio/detail/config.hpp
+++ b/yasio/detail/config.hpp
@@ -129,6 +129,11 @@ SOFTWARE.
 // #define YASIO_OBS_BUILTIN_STACK 1
 
 /*
+** Uncomment or add compiler flag -DYASIO_DISABLE_POLL to use socket.select for all platforms
+*/
+// #define YASIO_DISABLE_POLL 1
+
+/*
 ** Workaround for 'vs2013 without full c++11 support', in the future, drop vs2013 support and
 ** follow 3 lines code will be removed
 */

--- a/yasio/detail/config.hpp
+++ b/yasio/detail/config.hpp
@@ -97,7 +97,7 @@ SOFTWARE.
 // #define YASIO_ENABLE_UDS 1
 
 /*
-** Uncomment or add compiler flag -DYASIO_NT_COMPAT_GAI for earlier versions of Windows XP
+** Uncomment or add compiler flag -DYASIO_NT_COMPAT_GAI for compatible with Windows XP
 ** see: https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo
 */
 // #define YASIO_NT_COMPAT_GAI 1
@@ -130,6 +130,7 @@ SOFTWARE.
 
 /*
 ** Uncomment or add compiler flag -DYASIO_DISABLE_POLL to use socket.select for all platforms
+** If you need support Windows XP, you need disable poll
 */
 // #define YASIO_DISABLE_POLL 1
 

--- a/yasio/detail/config.hpp
+++ b/yasio/detail/config.hpp
@@ -238,14 +238,4 @@ SOFTWARE.
 #define YASIO_SSL_PIN "yasio_ssl_client"
 #define YASIO_SSL_PIN_LEN (sizeof(YASIO_SSL_PIN) - 1)
 
-
-/*
-** yasio bitop macros
-*/
-
-#define yasio__setbits(x, m) ((x) |= (m))
-#define yasio__clearbits(x, m) ((x) &= ~(m))
-#define yasio__testbits(x, m) ((x) & (m))
-#define yasio__setlobyte(x, v) ((x) = ((x) & ~((decltype(x))0xff)) | (v))
-
 #endif

--- a/yasio/detail/config.hpp
+++ b/yasio/detail/config.hpp
@@ -192,7 +192,7 @@ SOFTWARE.
 /*
 **  The yasio version macros
 */
-#define YASIO_VERSION_NUM 0x033905
+#define YASIO_VERSION_NUM 0x033906
 
 /*
 ** The macros used by io_service.
@@ -231,5 +231,15 @@ SOFTWARE.
 // The yasio ssl client PIN for server to recognize
 #define YASIO_SSL_PIN "yasio_ssl_client"
 #define YASIO_SSL_PIN_LEN (sizeof(YASIO_SSL_PIN) - 1)
+
+
+/*
+** yasio bitop macros
+*/
+
+#define yasio__setbits(x, m) ((x) |= (m))
+#define yasio__clearbits(x, m) ((x) &= ~(m))
+#define yasio__testbits(x, m) ((x) & (m))
+#define yasio__setlobyte(x, v) ((x) = ((x) & ~((decltype(x))0xff)) | (v))
 
 #endif

--- a/yasio/detail/fd_set_adapter.hpp
+++ b/yasio/detail/fd_set_adapter.hpp
@@ -8,8 +8,6 @@
 //
 // Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)
 
-// see also: https://github.com/chriskohlhoff/asio
-//
 #pragma once
 
 #include "yasio/detail/config.hpp"

--- a/yasio/detail/fd_set_adapter.hpp
+++ b/yasio/detail/fd_set_adapter.hpp
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+// A multi-platform support c++11 library with focus on asynchronous socket I/O for any
+// client application.
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// detail/fd_set_adapter.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)
+
+// see also: https://github.com/chriskohlhoff/asio
+//
+#pragma once
+
+#include "yasio/detail/config.hpp"
+
+#if !defined(YASIO_DISABLE_POLL)
+#  include "yasio/detail/poll_fd_set.hpp"
+#else
+#  include "yasio/detail/select_fd_set.hpp"
+#endif
+
+namespace yasio
+{
+YASIO__NS_INLINE
+namespace inet
+{
+#if !defined(YASIO_DISABLE_POLL)
+using fd_set_adapter = poll_fd_set;
+#else
+using fd_set_adapter = select_fd_set;
+#endif
+} // namespace inet
+} // namespace yasio

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -25,9 +25,11 @@ public:
     return *this;
   }
 
-  int do_poll(long long wait_duration) { return ::poll(this->fd_set_.data(), static_cast<int>(this->fd_set_.size()), wait_duration / 1000); }
+  void reset() { this->fd_set_.clear(); }
 
-  int has_events(socket_native_type fd, int events) const
+  int poll_io(timeval& waitd_tv) { return ::poll(this->fd_set_.data(), static_cast<int>(this->fd_set_.size()), waitd_tv.tv_sec * 1000 + waitd_tv.tv_usec / 1000); }
+
+  int is_set(socket_native_type fd, int events) const
   {
     int underlying_events = 0;
     if (events & socket_event::read)
@@ -40,9 +42,7 @@ public:
     return it != this->fd_set_.end() ? (it->revents & underlying_events) : 0;
   }
 
-  void reset() { this->fd_set_.clear(); }
-
-  void register_descriptor(socket_native_type fd, int events)
+  void set(socket_native_type fd, int events)
   {
     int underlying_flags = 0;
     if (yasio__testbits(events, socket_event::read))
@@ -56,7 +56,7 @@ public:
     pollfd_mod(this->fd_set_, fd, underlying_flags, 0);
   }
 
-  void deregister_descriptor(socket_native_type fd, int events)
+  void unset(socket_native_type fd, int events)
   {
     int underlying_flags = 0;
     if (yasio__testbits(events, socket_event::read))

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -1,0 +1,98 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+// A multi-platform support c++11 library with focus on asynchronous socket I/O for any
+// client application.
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// detail/poll_event_registry.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)
+
+#pragma once
+#include <vector>
+#include "yasio/detail/socket.hpp"
+
+namespace yasio
+{
+YASIO__NS_INLINE
+namespace inet
+{
+class poll_fd_set {
+public:
+  poll_fd_set& operator=(poll_fd_set& rhs)
+  {
+    this->fd_set_ = rhs.fd_set_;
+    return *this;
+  }
+
+  int poll_wait(long long timeout_usec) { return ::poll(this->fd_set_.data(), static_cast<int>(this->fd_set_.size()), timeout_usec / 1000); }
+
+  int has_events(socket_native_type fd, int events) const
+  {
+    int underlying_events = 0;
+    if (events & socket_event::read)
+      underlying_events |= POLLIN;
+    if (events & socket_event::write)
+      underlying_events |= POLLOUT;
+    if (events & socket_event::error)
+      underlying_events |= (POLLERR | POLLHUP | POLLNVAL);
+    auto it = std::find_if(this->fd_set_.begin(), this->fd_set_.end(), [fd](const pollfd& pfd) { return pfd.fd == fd; });
+    return it != this->fd_set_.end() ? (it->revents & underlying_events) : 0;
+  }
+
+  void reset() { this->fd_set_.clear(); }
+
+  void register_descriptor(socket_native_type fd, int events)
+  {
+    int underlying_flags = 0;
+    if (yasio__testbits(events, socket_event::read))
+      underlying_flags |= POLLIN;
+
+    if (yasio__testbits(events, socket_event::write))
+      underlying_flags |= POLLOUT;
+
+    if (yasio__testbits(events, socket_event::error))
+      underlying_flags |= POLLERR;
+    pollfd_mod(this->fd_set_, fd, underlying_flags, 0);
+  }
+
+  void deregister_descriptor(socket_native_type fd, int events)
+  {
+    int underlying_flags = 0;
+    if (yasio__testbits(events, socket_event::read))
+      underlying_flags |= POLLIN;
+
+    if (yasio__testbits(events, socket_event::write))
+      underlying_flags |= POLLOUT;
+
+    if (yasio__testbits(events, socket_event::error))
+      underlying_flags |= POLLERR;
+
+    pollfd_mod(this->fd_set_, fd, 0, underlying_flags);
+  }
+
+protected:
+  static void pollfd_mod(std::vector<pollfd>& fdset, socket_native_type fd, int add_flags, int remove_flags)
+  {
+    auto it = std::find_if(fdset.begin(), fdset.end(), [fd](const pollfd& pfd) { return pfd.fd == fd; });
+    if (it != fdset.end())
+    {
+      // POLLIN
+      it->events |= add_flags;
+      it->events &= ~remove_flags;
+      if (it->events == 0)
+        fdset.erase(it);
+    }
+    else
+    {
+      auto combined_flags = add_flags & ~remove_flags;
+      if (combined_flags)
+        fdset.push_back(pollfd{fd, static_cast<short>(combined_flags), 0});
+    }
+  }
+
+protected:
+  std::vector<pollfd> fd_set_;
+};
+} // namespace inet
+} // namespace yasio

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -7,7 +7,6 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
 // Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)
-
 #pragma once
 #include <vector>
 #include "yasio/detail/socket.hpp"

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -3,7 +3,7 @@
 // client application.
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-// detail/poll_event_registry.hpp
+// detail/poll_fd_set.hpp
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
 // Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -25,7 +25,7 @@ public:
     return *this;
   }
 
-  int poll_wait(long long timeout_usec) { return ::poll(this->fd_set_.data(), static_cast<int>(this->fd_set_.size()), timeout_usec / 1000); }
+  int do_poll(long long wait_duration) { return ::poll(this->fd_set_.data(), static_cast<int>(this->fd_set_.size()), wait_duration / 1000); }
 
   int has_events(socket_native_type fd, int events) const
   {

--- a/yasio/detail/poll_fd_set.hpp
+++ b/yasio/detail/poll_fd_set.hpp
@@ -43,50 +43,49 @@ public:
 
   void set(socket_native_type fd, int events)
   {
-    int underlying_flags = 0;
+    int underlying_events = 0;
     if (yasio__testbits(events, socket_event::read))
-      underlying_flags |= POLLIN;
+      underlying_events |= POLLIN;
 
     if (yasio__testbits(events, socket_event::write))
-      underlying_flags |= POLLOUT;
+      underlying_events |= POLLOUT;
 
     if (yasio__testbits(events, socket_event::error))
-      underlying_flags |= POLLERR;
-    pollfd_mod(this->fd_set_, fd, underlying_flags, 0);
+      underlying_events |= POLLERR;
+    pollfd_mod(this->fd_set_, fd, underlying_events, 0);
   }
 
   void unset(socket_native_type fd, int events)
   {
-    int underlying_flags = 0;
+    int underlying_events = 0;
     if (yasio__testbits(events, socket_event::read))
-      underlying_flags |= POLLIN;
+      underlying_events |= POLLIN;
 
     if (yasio__testbits(events, socket_event::write))
-      underlying_flags |= POLLOUT;
+      underlying_events |= POLLOUT;
 
     if (yasio__testbits(events, socket_event::error))
-      underlying_flags |= POLLERR;
+      underlying_events |= POLLERR;
 
-    pollfd_mod(this->fd_set_, fd, 0, underlying_flags);
+    pollfd_mod(this->fd_set_, fd, 0, underlying_events);
   }
 
 protected:
-  static void pollfd_mod(std::vector<pollfd>& fdset, socket_native_type fd, int add_flags, int remove_flags)
+  static void pollfd_mod(std::vector<pollfd>& fdset, socket_native_type fd, int add_events, int remove_events)
   {
     auto it = std::find_if(fdset.begin(), fdset.end(), [fd](const pollfd& pfd) { return pfd.fd == fd; });
     if (it != fdset.end())
     {
-      // POLLIN
-      it->events |= add_flags;
-      it->events &= ~remove_flags;
+      it->events |= add_events;
+      it->events &= ~remove_events;
       if (it->events == 0)
         fdset.erase(it);
     }
     else
     {
-      auto combined_flags = add_flags & ~remove_flags;
-      if (combined_flags)
-        fdset.push_back(pollfd{fd, static_cast<short>(combined_flags), 0});
+      auto events = add_events & ~remove_events;
+      if (events)
+        fdset.push_back(pollfd{fd, static_cast<short>(events), 0});
     }
   }
 

--- a/yasio/detail/select_fd_set.hpp
+++ b/yasio/detail/select_fd_set.hpp
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+// A multi-platform support c++11 library with focus on asynchronous socket I/O for any
+// client application.
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// detail/poll_reactor.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)
+#pragma once
+
+#include <vector>
+#include "yasio/detail/socket.hpp"
+
+namespace yasio
+{
+YASIO__NS_INLINE
+namespace inet
+{
+class select_fd_set {
+public:
+  select_fd_set() { 
+    reset();
+  }
+  // TODO: cb
+  int poll_events(int timeout, select_fd_set& revents)
+  {
+    // std::copy(this->fd_set_.begin(), this->fd_set_.end(), std::back_inserter(revents.fd_set_));
+    // return ::poll(revents, revents.count(), timeout);
+  }
+
+  int has_events(socket_native_type fd, int events) const
+  {
+    
+  }
+
+  void reset()
+  {
+    FD_ZERO(&fd_set_[read_op]);
+    FD_ZERO(&fd_set_[write_op]);
+    FD_ZERO(&fd_set_[except_op]);
+    max_nfds_ = 0;
+  }
+
+  void register_descriptor(socket_native_type fd, int events)
+  {
+    if (yasio__testbits(events, YEM_POLLIN))
+      FD_SET(fd, &(fd_set_[read_op]));
+
+    if (yasio__testbits(events, YEM_POLLOUT))
+      FD_SET(fd, &(fd_set_[write_op]));
+
+    if (yasio__testbits(events, YEM_POLLERR))
+      FD_SET(fd, &(fd_set_[except_op]));
+
+    if (max_nfds_ < static_cast<int>(fd) + 1)
+      max_nfds_ = static_cast<int>(fd) + 1;
+  }
+
+  void deregister_descriptor(socket_native_type fd, int events)
+  {
+    if (yasio__testbits(events, YEM_POLLIN))
+      FD_CLR(fd, &(fd_set_[read_op]));
+
+    if (yasio__testbits(events, YEM_POLLOUT))
+      FD_CLR(fd, &(fd_set_[write_op]));
+
+    if (yasio__testbits(events, YEM_POLLERR))
+      FD_CLR(fd, &(fd_set_[except_op]));
+  }
+
+protected:
+
+protected:
+  enum
+  {
+    read_op,
+    write_op,
+    except_op,
+    max_ops,
+  };
+  fd_set fd_set_[max_ops];
+  int max_nfds_ = 0;
+};
+} // namespace inet
+} // namespace yasio

--- a/yasio/detail/select_fd_set.hpp
+++ b/yasio/detail/select_fd_set.hpp
@@ -3,7 +3,7 @@
 // client application.
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-// detail/poll_reactor.hpp
+// detail/select_fd_set.hpp
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
 // Copyright (c) 2012-2022 HALX99 (halx99 at live dot com)

--- a/yasio/detail/socket.hpp
+++ b/yasio/detail/socket.hpp
@@ -228,6 +228,11 @@ inline bool IN6_IS_ADDR_GLOBAL(const in6_addr* a)
 
 #define YASIO_ADDR_ANY(af) (af == AF_INET ? "0.0.0.0" : "::")
 
+#define yasio__setbits(x, m) ((x) |= (m))
+#define yasio__clearbits(x, m) ((x) &= ~(m))
+#define yasio__testbits(x, m) ((x) & (m))
+#define yasio__setlobyte(x, v) ((x) = ((x) & ~((decltype(x))0xff)) | (v))
+
 namespace yasio
 {
 YASIO__NS_INLINE

--- a/yasio/detail/socket.hpp
+++ b/yasio/detail/socket.hpp
@@ -228,4 +228,20 @@ inline bool IN6_IS_ADDR_GLOBAL(const in6_addr* a)
 
 #define YASIO_ADDR_ANY(af) (af == AF_INET ? "0.0.0.0" : "::")
 
+namespace yasio
+{
+YASIO__NS_INLINE
+namespace inet
+{
+struct socket_event {
+  enum
+  { // event mask
+    read  = 1,
+    write = 2,
+    error = 4,
+    readwrite = read | write,
+  };
+};
+}
+} // namespace yasio
 #endif

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -1283,7 +1283,7 @@ void io_service::do_connect_completion(io_channel* ctx)
   {
     int error = -1;
 #if !defined(YASIO_SSL_BACKEND)
-    if (FD_ISSET(ctx->socket_->native_handle(), &fds_array[write_op]) || FD_ISSET(ctx->socket_->native_handle(), &fds_array[read_op]))
+    if (pollfd_isset(ctx->socket_->native_handle(), POLLIN | POLLOUT))
     {
       if (ctx->socket_->get_optval(SOL_SOCKET, SO_ERROR, error) >= 0 && error == 0)
       {

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -1211,7 +1211,7 @@ void io_service::do_connect_completion(io_channel* ctx, poll_fd_set& fd_set)
   {
     int error = -1;
 #if !defined(YASIO_SSL_BACKEND)
-    if (pollfd_isset(ctx->socket_->native_handle(), POLLIN | POLLOUT))
+    if (fd_set.has_events(ctx->socket_->native_handle(), socket_event::readwrite))
     {
       if (ctx->socket_->get_optval(SOL_SOCKET, SO_ERROR, error) >= 0 && error == 0)
       {

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -1083,8 +1083,8 @@ void io_service::handle_close(transport_handle_t thandle)
     cleanup_channel(ctx, false);
   }
 }
-void io_service::register_descriptor(const socket_native_type fd, int flags) { this->fd_set_.set(fd, flags); }
-void io_service::deregister_descriptor(const socket_native_type fd, int flags) { this->fd_set_.unset(fd, flags); }
+void io_service::register_descriptor(const socket_native_type fd, int events) { this->fd_set_.set(fd, events); }
+void io_service::deregister_descriptor(const socket_native_type fd, int events) { this->fd_set_.unset(fd, events); }
 
 int io_service::write(transport_handle_t transport, dynamic_buffer_t buffer, completion_cb_t handler)
 {

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -892,7 +892,7 @@ void io_service::run()
   // The core event loop
   this->wait_duration_ = YASIO_MAX_WAIT_DURATION;
 
-  poll_fd_set revents; // file_descriptor_set
+  fd_set_adapter revents; // file_descriptor_set
 
   do
   {
@@ -965,7 +965,7 @@ void io_service::run()
 
   this->state_ = io_service::state::AT_EXITING;
 }
-void io_service::process_transports(poll_fd_set& revents)
+void io_service::process_transports(fd_set_adapter& revents)
 {
   // preform transports
   for (auto iter = transports_.begin(); iter != transports_.end();)
@@ -987,7 +987,7 @@ void io_service::process_transports(poll_fd_set& revents)
     iter = transports_.erase(iter);
   }
 }
-void io_service::process_channels(poll_fd_set& revents)
+void io_service::process_channels(fd_set_adapter& revents)
 {
   if (!this->channel_ops_.empty())
   {
@@ -1201,7 +1201,7 @@ void io_service::do_connect(io_channel* ctx)
     this->handle_connect_failed(ctx, xxsocket::get_last_errno());
 }
 
-void io_service::do_connect_completion(io_channel* ctx, poll_fd_set& fd_set)
+void io_service::do_connect_completion(io_channel* ctx, fd_set_adapter& fd_set)
 {
   assert(ctx->state_ == io_base::state::CONNECTING);
   if (ctx->state_ == io_base::state::CONNECTING)
@@ -1442,7 +1442,7 @@ void io_service::ares_getaddrinfo_cb(void* arg, int status, int /*timeouts*/, ar
   }
   current_service.interrupt();
 }
-void io_service::process_ares_requests(socket_native_type* socks, int count, poll_fd_set& revents)
+void io_service::process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& revents)
 {
   if (this->ares_outstanding_work_ > 0)
   {
@@ -1579,7 +1579,7 @@ void io_service::do_accept(io_channel* ctx)
   handle_event(cxx14::make_unique<io_event>(ctx->index_, YEK_ON_OPEN, error, ctx, 1));
 #endif
 }
-void io_service::do_accept_completion(io_channel* ctx, poll_fd_set& revents)
+void io_service::do_accept_completion(io_channel* ctx, fd_set_adapter& revents)
 {
   if (ctx->state_ == io_base::state::OPENED)
   {
@@ -1770,7 +1770,7 @@ void io_service::handle_connect_failed(io_channel* ctx, int error)
   YASIO_KLOGE("[index: %d] connect server %s failed, ec=%d, detail:%s", ctx->index_, ctx->format_destination().c_str(), error, io_service::strerror(error));
   handle_event(cxx14::make_unique<io_event>(ctx->index_, YEK_ON_OPEN, error, ctx));
 }
-bool io_service::do_read(transport_handle_t transport, poll_fd_set& revents)
+bool io_service::do_read(transport_handle_t transport, fd_set_adapter& revents)
 {
   bool ret = false;
   do

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -921,7 +921,7 @@ void io_service::run()
         ::ares_timeout(this->ares_, &waitd_tv, &waitd_tv);
       }
 #endif
-      int retval = revents.poll_wait(static_cast<int>(wait_duration / 1000));
+      int retval = revents.poll_wait(wait_duration);
       //YASIO_KLOGV("[core] poll waiting... %ld milliseconds", waitd_tv.tv_sec * 1000 + waitd_tv.tv_usec / 1000);
       //int retval = ::poll(this->pollfds.data(), this->pollfds.size(), static_cast<int>(wait_duration / 1000));
       //YASIO_KLOGV("[core] poll waked up, retval=%d", retval);

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -921,10 +921,7 @@ void io_service::run()
         ::ares_timeout(this->ares_, &waitd_tv, &waitd_tv);
       }
 #endif
-      int retval = revents.poll_wait(wait_duration);
-      //YASIO_KLOGV("[core] poll waiting... %ld milliseconds", waitd_tv.tv_sec * 1000 + waitd_tv.tv_usec / 1000);
-      //int retval = ::poll(this->pollfds.data(), this->pollfds.size(), static_cast<int>(wait_duration / 1000));
-      //YASIO_KLOGV("[core] poll waked up, retval=%d", retval);
+      int retval = revents.do_poll(wait_duration);
       if (retval < 0)
       {
         int ec = xxsocket::get_last_errno();

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -902,7 +902,7 @@ void io_service::run()
       timeval waitd_tv = {(decltype(timeval::tv_sec))(wait_duration / 1000000), (decltype(timeval::tv_usec))(wait_duration % 1000000)};
 #if defined(YASIO_HAVE_CARES)
       if (ares_outstanding_work_) {
-        ares_socks_count = set_ares_fds(ares_socks, fd_set);
+        ares_socks_count = register_ares_fds(ares_socks, fd_set);
         ::ares_timeout(this->ares_, &waitd_tv, &waitd_tv);
       }
 #endif
@@ -1427,7 +1427,7 @@ void io_service::ares_getaddrinfo_cb(void* arg, int status, int /*timeouts*/, ar
   }
   current_service.interrupt();
 }
-int io_service::set_ares_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set)
+int io_service::register_ares_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set)
 {
   int count = 0;
   int bitmask = ::ares_getsock(this->ares_, ares_socks, ARES_GETSOCK_MAXNUM);

--- a/yasio/yasio.cpp
+++ b/yasio/yasio.cpp
@@ -1216,7 +1216,7 @@ void io_service::do_connect_completion(io_channel* ctx, poll_fd_set& fd_set)
       if (ctx->socket_->get_optval(SOL_SOCKET, SO_ERROR, error) >= 0 && error == 0)
       {
         // The nonblocking tcp handshake complete, remove write event avoid high-CPU occupation
-        unregister_descriptor(ctx->socket_->native_handle(), YEM_POLLOUT);
+        unregister_descriptor(ctx->socket_->native_handle(), socket_event::write);
         handle_connect_succeed(ctx, ctx->socket_);
       }
       else

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1063,8 +1063,8 @@ private:
 
   YASIO__DECL bool open_internal(io_channel*);
 
-  YASIO__DECL void process_transports(fd_set_adapter& revents);
-  YASIO__DECL void process_channels(fd_set_adapter& revents);
+  YASIO__DECL void process_transports(fd_set_adapter& fd_set);
+  YASIO__DECL void process_channels(fd_set_adapter& fd_set);
   YASIO__DECL void process_timers();
 
   YASIO__DECL void interrupt();
@@ -1085,7 +1085,7 @@ private:
   YASIO__DECL static void ares_getaddrinfo_cb(void* arg, int status, int timeouts, ares_addrinfo* answerlist);
   YASIO__DECL void ares_work_started();
   YASIO__DECL void ares_work_finished();
-  YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& revents);
+  YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& fd_set);
   YASIO__DECL void recreate_ares_channel();
   YASIO__DECL void config_ares_name_servers();
   YASIO__DECL void destroy_ares_channel();
@@ -1100,12 +1100,12 @@ private:
   YASIO__DECL void deallocate_transport(transport_handle_t);
 
   YASIO__DECL void register_descriptor(const socket_native_type fd, int flags);
-  YASIO__DECL void unregister_descriptor(const socket_native_type fd, int flags);
+  YASIO__DECL void deregister_descriptor(const socket_native_type fd, int flags);
 
   // The major non-blocking event-loop
   YASIO__DECL void run(void);
 
-  YASIO__DECL bool do_read(transport_handle_t, fd_set_adapter& revents);
+  YASIO__DECL bool do_read(transport_handle_t, fd_set_adapter& fd_set);
   bool do_write(transport_handle_t transport) { return transport->do_write(this->wait_duration_); }
   YASIO__DECL void unpack(transport_handle_t, int bytes_expected, int bytes_transferred, int bytes_to_strip);
 
@@ -1128,7 +1128,7 @@ private:
 
   // supporting server
   YASIO__DECL void do_accept(io_channel*);
-  YASIO__DECL void do_accept_completion(io_channel*, fd_set_adapter& revents);
+  YASIO__DECL void do_accept_completion(io_channel*, fd_set_adapter& fd_set);
 
   YASIO__DECL static const char* strerror(int error);
 

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1070,8 +1070,6 @@ private:
 
   YASIO__DECL highp_time_t get_timeout(highp_time_t usec);
 
-  YASIO__DECL int poll_wait(highp_time_t wait_duration, socket_native_type* ares_socks);
-
   YASIO__DECL int do_resolve(io_channel* ctx);
   YASIO__DECL void do_connect(io_channel*);
   YASIO__DECL void do_connect_completion(io_channel*);

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -48,7 +48,7 @@ SOFTWARE.
 #include "yasio/detail/utils.hpp"
 #include "yasio/detail/errc.hpp"
 #include "yasio/detail/byte_buffer.hpp"
-#include "yasio/detail/poll_fd_set.hpp"
+#include "yasio/detail/fd_set_adapter.hpp"
 #include "yasio/cxx17/memory.hpp"
 #include "yasio/cxx17/string_view.hpp"
 #include "yasio/xxsocket.hpp"
@@ -1063,8 +1063,8 @@ private:
 
   YASIO__DECL bool open_internal(io_channel*);
 
-  YASIO__DECL void process_transports(poll_fd_set& revents);
-  YASIO__DECL void process_channels(poll_fd_set& revents);
+  YASIO__DECL void process_transports(fd_set_adapter& revents);
+  YASIO__DECL void process_channels(fd_set_adapter& revents);
   YASIO__DECL void process_timers();
 
   YASIO__DECL void interrupt();
@@ -1073,7 +1073,7 @@ private:
 
   YASIO__DECL int do_resolve(io_channel* ctx);
   YASIO__DECL void do_connect(io_channel*);
-  YASIO__DECL void do_connect_completion(io_channel*, poll_fd_set& fd_set);
+  YASIO__DECL void do_connect_completion(io_channel*, fd_set_adapter& fd_set);
 
 #if defined(YASIO_SSL_BACKEND)
   YASIO__DECL void init_ssl_context();
@@ -1085,7 +1085,7 @@ private:
   YASIO__DECL static void ares_getaddrinfo_cb(void* arg, int status, int timeouts, ares_addrinfo* answerlist);
   YASIO__DECL void ares_work_started();
   YASIO__DECL void ares_work_finished();
-  YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, poll_fd_set& revents);
+  YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& revents);
   YASIO__DECL void recreate_ares_channel();
   YASIO__DECL void config_ares_name_servers();
   YASIO__DECL void destroy_ares_channel();
@@ -1105,7 +1105,7 @@ private:
   // The major non-blocking event-loop
   YASIO__DECL void run(void);
 
-  YASIO__DECL bool do_read(transport_handle_t, poll_fd_set& revents);
+  YASIO__DECL bool do_read(transport_handle_t, fd_set_adapter& revents);
   bool do_write(transport_handle_t transport) { return transport->do_write(this->wait_duration_); }
   YASIO__DECL void unpack(transport_handle_t, int bytes_expected, int bytes_transferred, int bytes_to_strip);
 
@@ -1128,7 +1128,7 @@ private:
 
   // supporting server
   YASIO__DECL void do_accept(io_channel*);
-  YASIO__DECL void do_accept_completion(io_channel*, poll_fd_set& revents);
+  YASIO__DECL void do_accept_completion(io_channel*, fd_set_adapter& revents);
 
   YASIO__DECL static const char* strerror(int error);
 
@@ -1171,7 +1171,7 @@ private:
   // the next wait duration for socket.select
   highp_time_t wait_duration_;
 
-  poll_fd_set fd_set_;
+  fd_set_adapter fd_set_;
 
   // options
   struct __unnamed_options {

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1085,6 +1085,7 @@ private:
   YASIO__DECL static void ares_getaddrinfo_cb(void* arg, int status, int timeouts, ares_addrinfo* answerlist);
   YASIO__DECL void ares_work_started();
   YASIO__DECL void ares_work_finished();
+  YASIO__DECL int ares_set_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set, timeval& waitd_tv);
   YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& fd_set);
   YASIO__DECL void recreate_ares_channel();
   YASIO__DECL void config_ares_name_servers();

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1085,7 +1085,7 @@ private:
   YASIO__DECL static void ares_getaddrinfo_cb(void* arg, int status, int timeouts, ares_addrinfo* answerlist);
   YASIO__DECL void ares_work_started();
   YASIO__DECL void ares_work_finished();
-  YASIO__DECL int ares_set_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set, timeval& waitd_tv);
+  YASIO__DECL int set_ares_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set);
   YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& fd_set);
   YASIO__DECL void recreate_ares_channel();
   YASIO__DECL void config_ares_name_servers();

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1100,8 +1100,8 @@ private:
   YASIO__DECL transport_handle_t allocate_transport(io_channel*, xxsocket_ptr&&);
   YASIO__DECL void deallocate_transport(transport_handle_t);
 
-  YASIO__DECL void register_descriptor(const socket_native_type fd, int flags);
-  YASIO__DECL void deregister_descriptor(const socket_native_type fd, int flags);
+  YASIO__DECL void register_descriptor(const socket_native_type fd, int events);
+  YASIO__DECL void deregister_descriptor(const socket_native_type fd, int events);
 
   // The major non-blocking event-loop
   YASIO__DECL void run(void);

--- a/yasio/yasio.hpp
+++ b/yasio/yasio.hpp
@@ -1085,7 +1085,7 @@ private:
   YASIO__DECL static void ares_getaddrinfo_cb(void* arg, int status, int timeouts, ares_addrinfo* answerlist);
   YASIO__DECL void ares_work_started();
   YASIO__DECL void ares_work_finished();
-  YASIO__DECL int set_ares_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set);
+  YASIO__DECL int register_ares_fds(socket_native_type* ares_socks, fd_set_adapter& fd_set);
   YASIO__DECL void process_ares_requests(socket_native_type* socks, int count, fd_set_adapter& fd_set);
   YASIO__DECL void recreate_ares_channel();
   YASIO__DECL void config_ares_name_servers();


### PR DESCRIPTION
- [x] Reimplement reactor backends: select, poll
- [x] Now the default reactor backend is poll
- [x] Add compiler flag `YASIO_DISABLE_POLL` for switching to socket.select as same with previous releases